### PR TITLE
Suggested Refactor

### DIFF
--- a/disable_prelinking.cf
+++ b/disable_prelinking.cf
@@ -1,35 +1,32 @@
 # Policy to disable prelinking
-
-bundle edit_line option_set_no(option)
-{
-  # Set option value to 'no'
-  replace_patterns:
-      "^$(option)=(?!no).*$"
-        replace_with => value("$(option)=no");
-}
-
 bundle agent disable_prelinking
 {
   # Enable autorun
   meta:
+    linux::
       "tags" slist => { "autorun" };
+
+  vars:
+      "_config_file"
+        string => ifelse( "suse|redhat", "/etc/sysconfig/prelink",
+                          "debian", "/etc/default/prelink",
+                          "/etc/default/prelink");
+      "_config[PRELINKING]" string => "no";
 
   # Disable prelink in configuration file
   files:
-      # Redhat systems
-      "/etc/sysconfig/prelink"
-        edit_line => option_set_no("PRELINKING"),
-        classes => if_repaired("prelink_config_file_repaired"),
-        if => fileexists("/etc/sysconfig/prelink");
 
-      # Debian systems
-      "/etc/default/prelink"
-        edit_line => option_set_no("PRELINKING"),
-        classes => if_repaired("prelink_config_file_repaired"),
-        if => fileexists("/etc/default/prelink");
+      "$(_config_file)" -> { "CCE-27078-5" }
+        create => "true",
+        edit_line => default:set_line_based("$(this.namespace):$(this.bundle)._config",
+                                    " ",
+                                    "\s+",
+                                    ".*",
+                                    "\s*#\s*"),
+        classes => default:results( "bundle", "prelink_config_file");
 
   # Implement changes if prelink configuration file was repaired
   commands:
     prelink_config_file_repaired::
-      "/etc/cron.daily/prelink";
+      "/usr/sbin/prelink -ua";
 }


### PR DESCRIPTION
- use set_line_based from the stdlib instead of defining a custom edit_line bundle
- Guard autorun to linux
- Use variable for configuration file path
- Distill into one promise for the file regardless of platform
- Create the file if it does not exist
- Use prelink (per openscap guide) instead of hoping the daily cron job exists