### PR TITLE
Fix check for prelink being available

### DIFF
--- a/disable_prelinking.cf
+++ b/disable_prelinking.cf
@@ -29,6 +29,7 @@ bundle agent disable_prelinking
 
   files:
     # Disable prelink in configuration file
+    _stdlib_path_exists_prelink::
       "$(_config_file)" -> { "CCE-27078-5" }
         create => "true",
         edit_line => set_line_based("$(this.bundle)._config",
@@ -38,6 +39,6 @@ bundle agent disable_prelinking
   commands:
     # Implement changes if prelink configuration file was repaired and path to
     # binary exists
-    prelink_config_file_repaired&_stdlib_path_exists_prelink::
+    prelink_config_file_repaired::
       "$(paths.prelink) -ua";
 }


### PR DESCRIPTION
If prelink sees another file `/etc/sysconfig/prelink` while being installed, it creates `/etc/sysconfig/prelink.rpmnew` instead. Therefor the module must not create a prelink config file, if it does not exist.

Signed-off-by: larsewi <lars.erik.wik@northern.tech>